### PR TITLE
Add dynamic save for both client and node

### DIFF
--- a/packages/auto-utils/package.json
+++ b/packages/auto-utils/package.json
@@ -7,12 +7,16 @@
     "test": "jest"
   },
   "dependencies": {
-    "@polkadot/api": "^11.2.1"
+    "@polkadot/api": "^11.2.1",
+    "fs": "^0.0.1-security"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.4",
     "typescript": "^5.4.5"
+  },
+  "browser": {
+    "fs": false
   }
 }

--- a/packages/auto-utils/src/index.ts
+++ b/packages/auto-utils/src/index.ts
@@ -1,2 +1,3 @@
 export * from './api'
 export * from './network'
+export * from './save'

--- a/packages/auto-utils/src/save.ts
+++ b/packages/auto-utils/src/save.ts
@@ -1,10 +1,7 @@
 export const save = async (key: string, value: any) => {
   // detect if we are in the browser or in node
-  if (typeof window !== 'undefined') {
-    await saveOnLocalStorage(key, value)
-  } else {
-    await saveOnFileSystem(key, value)
-  }
+  if (typeof window !== 'undefined') await saveOnLocalStorage(key, value)
+  else await saveOnFileSystem(key, value)
 }
 
 export const saveOnLocalStorage = async (key: string, value: any) => {

--- a/packages/auto-utils/src/save.ts
+++ b/packages/auto-utils/src/save.ts
@@ -1,0 +1,23 @@
+export const save = async (key: string, value: any) => {
+  // detect if we are in the browser or in node
+  if (typeof window !== 'undefined') {
+    await saveOnLocalStorage(key, value)
+  } else {
+    await saveOnFileSystem(key, value)
+  }
+}
+
+export const saveOnLocalStorage = async (key: string, value: any) => {
+  if (typeof window !== 'undefined')
+    // save on local storage
+    localStorage.setItem(key, JSON.stringify(value))
+  else throw new Error('This function can only be used in the browser')
+}
+
+export const saveOnFileSystem = async (key: string, value: any) => {
+  if (typeof window === 'undefined') {
+    // save on file system
+    const fs = await import('fs/promises')
+    await fs.writeFile(key, JSON.stringify(value))
+  } else throw new Error('This function can only be used in node')
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,6 +51,7 @@ __metadata:
   dependencies:
     "@polkadot/api": "npm:^11.2.1"
     "@types/jest": "npm:^29.5.12"
+    fs: "npm:^0.0.1-security"
     jest: "npm:^29.7.0"
     ts-jest: "npm:^29.1.4"
     typescript: "npm:^5.4.5"
@@ -2571,6 +2572,13 @@ __metadata:
   version: 1.0.0
   resolution: "fs.realpath@npm:1.0.0"
   checksum: 10c0/444cf1291d997165dfd4c0d58b69f0e4782bfd9149fd72faa4fe299e68e0e93d6db941660b37dd29153bf7186672ececa3b50b7e7249477b03fdf850f287c948
+  languageName: node
+  linkType: hard
+
+"fs@npm:^0.0.1-security":
+  version: 0.0.1-security
+  resolution: "fs@npm:0.0.1-security"
+  checksum: 10c0/e0c0b585ec6f7483d63d067215d9d6bb2e0dba5912060d32554c8e566a0e22ee65e4c2a2b0567476efbbfb47682554b4711d69cab49950d01f227a3dfa7d671a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Add dynamic save for both client and node

- Add a generic dynamic save function that both support local storage or file system (use the key as the fileName + extension in the case of a file system