### PR TITLE
Add a scripts folder in root with bash script that can run a local testnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ tsconfig.tsbuildinfo
 
 # Environment variables
 .env
+
+# Directory use by scripts
+executables/
+downloads/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,36 @@ To run tests for all packages:
 
 `yarn test`
 
+### Localhost testing
+
+To test the packages against a local node, you can use the script at `scripts/localhost.sh`.
+
+1. Verify that the line 3-7 of the script matches your current OS and architecture.
+
+   ```bash
+   # Change the following variables as needed
+   # OS to download
+   OS="macos" # macos | ubuntu | windows
+   # Architecture to download
+   ARCHITECTURE="aarch64" # aarch64 | x86_64-skylake | x86_64-v2
+   ```
+
+2. Run the script:
+
+   ```bash
+   ./scripts/localhost.sh
+   ```
+
+   This script will download the latest version of the node and farmer for your OS and architecture, start the node, and farmer
+
+3. Run the tests:
+
+   ```bash
+   bash scripts/localhost-run-test.sh
+   ```
+
+   The tests will detect the local node and farmer and run the tests against them instead of the public testnet.
+
 ## Workspaces
 
 This project uses Yarn workspaces. Packages are located in the `packages` directory. Each package can have its own dependencies and build scripts.

--- a/packages/auto-utils/__test__/network.test.ts
+++ b/packages/auto-utils/__test__/network.test.ts
@@ -2,7 +2,13 @@ import { defaultNetwork, networks } from '../src/constants/network'
 import { getNetworkDetails, getNetworkRpcUrls } from '../src/network'
 
 describe('Verify network functions', () => {
-  const TEST_NETWORK = { networkId: networks[0].id }
+  const isLocalhost = process.env.LOCALHOST === 'true'
+
+  // Define the test network and its details
+  const TEST_NETWORK = !isLocalhost ? { networkId: networks[0].id } : { networkId: 'autonomys-localhost' }
+  const TEST_NETWORK_DETAIL = networks.find((network) => network.id === TEST_NETWORK.networkId)
+  if (!TEST_NETWORK_DETAIL) throw new Error(`Network with id ${TEST_NETWORK.networkId} not found`)
+  
   const TEST_INVALID_NETWORK = { networkId: 'invalid-network' }
 
   test('Check getNetworkDetails return all network detail', async () => {
@@ -17,12 +23,12 @@ describe('Verify network functions', () => {
 
   test('Check getNetworkDetails return the network detail for a specific network', async () => {
     const rpcUrls = getNetworkDetails(TEST_NETWORK)
-    expect(rpcUrls).toEqual(networks[0])
+    expect(rpcUrls).toEqual(TEST_NETWORK_DETAIL)
   })
 
   test('Check getNetworkRpcUrls return the network urls for a specific network', async () => {
     const rpcUrls = getNetworkRpcUrls(TEST_NETWORK)
-    expect(rpcUrls).toEqual(networks[0].rpcUrls)
+    expect(rpcUrls).toEqual(TEST_NETWORK_DETAIL.rpcUrls)
   })
 
   test('Check getNetworkDetails return the network urls for an invalid network', async () => {

--- a/packages/auto-utils/src/constants/network.ts
+++ b/packages/auto-utils/src/constants/network.ts
@@ -55,6 +55,7 @@ export const networks: Network[] = [
       },
     ],
     isTestnet: true,
+    isLocalhost: true,
   },
 ]
 

--- a/scripts/localhost-run-test.sh
+++ b/scripts/localhost-run-test.sh
@@ -1,0 +1,4 @@
+LOCALHOST="true"
+export LOCALHOST
+
+yarn test

--- a/scripts/localhost.sh
+++ b/scripts/localhost.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Change the following variables as needed
+# OS to download
+OS="macos" # macos | ubuntu | windows
+# Architecture to download
+ARCHITECTURE="aarch64" # aarch64 | x86_64-skylake | x86_64-v2
+
+# GitHub repository
+REPO="subspace/subspace"
+
+# Directories
+DOWNLOAD_DIR="downloads"
+EXECUTABLE_DIR="executables"
+
+# Create directories if they do not exist
+mkdir -p "$DOWNLOAD_DIR"
+mkdir -p "$EXECUTABLE_DIR"
+
+# Get the latest release data
+RELEASE_DATA=$(curl -s "https://api.github.com/repos/$REPO/releases/latest")
+
+# Extract the download URLs for the selected os and architecture node and farmer assets
+NODE_URL=$(echo $RELEASE_DATA | jq -r '.assets[] | select(.name | contains("subspace-node-'$OS'-'$ARCHITECTURE'")) | .browser_download_url')
+FARMER_URL=$(echo $RELEASE_DATA | jq -r '.assets[] | select(.name | contains("subspace-farmer-'$OS'-'$ARCHITECTURE'")) | .browser_download_url')
+
+# Download the assets
+curl -L -o "$DOWNLOAD_DIR/node.zip" "$NODE_URL"
+curl -L -o "$DOWNLOAD_DIR/farmer.zip" "$FARMER_URL"
+
+# Unzip the downloaded files
+unzip -o "$DOWNLOAD_DIR/node.zip" -d "$EXECUTABLE_DIR/node_temp"
+unzip -o "$DOWNLOAD_DIR/farmer.zip" -d "$EXECUTABLE_DIR/farmer_temp"
+
+# Rename extracted directories to node and farmer
+mv "$EXECUTABLE_DIR"/node_temp/* "$EXECUTABLE_DIR/node"
+mv "$EXECUTABLE_DIR"/farmer_temp/* "$EXECUTABLE_DIR/farmer"
+
+# Remove temporary directories
+rmdir "$EXECUTABLE_DIR/node_temp"
+rmdir "$EXECUTABLE_DIR/farmer_temp"
+
+# Clean up zip files
+rm "$DOWNLOAD_DIR/node.zip" "$DOWNLOAD_DIR/farmer.zip"
+
+# Make the binaries executable
+chmod +X "$EXECUTABLE_DIR/node"
+chmod +x "$EXECUTABLE_DIR/farmer"
+
+# Delete the downloads directory
+rmdir "$DOWNLOAD_DIR"
+
+echo "Downloaded and unzipped the latest node and farmer assets."
+
+# Run node in the background
+echo "Running node in the background..."
+./executables/node run --dev --tmp --base-path executables/node-temp --farmer --name "localhost-node" --rpc-rate-limit 1000 --rpc-max-connections 10000 &
+
+# Wait for 10 seconds before starting farmer
+echo "Waiting for 10 seconds before starting farmer..."
+sleep 10
+
+# Run farmer
+echo "Running farmer in the background..."
+./executables/farmer farm --reward-address 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY path=executables/farmer-temp,size=1GiB &
+
+echo "Both node and farmer are running in parallel."


### PR DESCRIPTION
## Add a scripts folder in root with bash script that can run a local testnet

Hopefully, this will make the development easier, especially as we start tackling extrinsics

### Localhost testing

To test the packages against a local node, you can use the script at `scripts/localhost.sh`.

1. Verify that the line 3-7 of the script matches your current OS and architecture.

   ```bash
   # Change the following variables as needed
   # OS to download
   OS="macos" # macos | ubuntu | windows
   # Architecture to download
   ARCHITECTURE="aarch64" # aarch64 | x86_64-skylake | x86_64-v2
   ```

2. Run the script:

   ```bash
   ./scripts/localhost.sh
   ```

   This script will download the latest version of the node and farmer for your OS and architecture, start the node, and farmer

3. Run the tests:

   ```bash
   bash scripts/localhost-run-test.sh
   ```

   The tests will detect the local node and farmer and run the tests against them instead of the public testnet.
